### PR TITLE
fix: portfolio__item-title height 비율 수정

### DIFF
--- a/portfolio/public/index.html
+++ b/portfolio/public/index.html
@@ -4,7 +4,8 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width", initial-scale="1.0">
-    <title> Document </title>
+    <title> Yeeun Heo </title>
+    <link rel="shortcut icon" type="image/x-icon" href="/src/assets/me.png">
 </head>
 <body>
     <div id="root"></div>

--- a/portfolio/src/components/portfolio/portfolio.css
+++ b/portfolio/src/components/portfolio/portfolio.css
@@ -29,7 +29,7 @@
 }
 
 .portfolio__item-title {
-    height: 5vh;
+    height: 20%;
     margin: 1.2rem 0 1rem;
     justify-content: center;
     align-items: center;


### PR DESCRIPTION
화면이 세로로 긴 상태에서도 portfolio item의 버튼이 item에 벗어나지 않도록 설정

close #1 

![스크린샷 2022-03-21 오후 9 24 04](https://user-images.githubusercontent.com/39258902/159260298-cd8762fd-f212-49e0-903d-29048cff5966.png)
